### PR TITLE
Typo Fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing
 
 This project is for Tigard High School's game submission to OGPC and as such we are not accepting pull
-requests from individuals outside of Tigard High students. If you have any suggestions please raise an issue, however we are not allowed to accept outside
-help for implementation. For this reason we ask that you keep your suggestions as general as possible without including any specific code snippets.
+requests from individuals outside of Tigard High students. If you have any suggestions please raise an issue however, we are not allowed to accept outside
+help for implementation. For this reason, we ask that you keep your suggestions as general as possible without including any specific code snippets.
 
 ## Game Club Members
 
@@ -18,16 +18,16 @@ programming and gaming that has driven us to be where we are today! Here are som
 - Open a pull request to merge your branch into main.
   - If there is an issue to be closed, please include the phrase `closes #<issue number>` in the description of the pull request.
 - Wait for a review from one of our team leaders.
-  - This process can take some time so please don't be surprised or discouraged if multiple iterations of changes are requested. Usually two approvals are required before we will merge your changes.
-- Once your changes are approved we will update the change log and merge your commits!
+  - This process can take some time so please don't be surprised or discouraged if multiple iterations of changes are requested. Usually, two approvals are required before we will merge your changes.
+- Once your changes are approved we will update the changelog and merge your commits!
   - Updating the change log can take some time so it's not uncommon for a pull request to sit `ready to merge` for a while.
 
 Any contributing questions can be directed to our team leaders, we are more than happy to help!
 
 ### Reviewing a Pull Request
 
-We usually require two approvals before considering a pull request ready to merge. These reviews mainly coming from our team leaders.
-We encourage everyone to get involved in the review process of all PRs. Even if you are not a requested reviewer you can still leave a review, wether you think all changes look good or you see something that can be changed!
+We usually require two approvals before considering a pull request ready to merge. These reviews are mainly coming from our team leaders.
+We encourage everyone to get involved in the review process of all PRs. Even if you are not a requested reviewer you can still leave a review, whether you think all changes look good or you see something that can be changed!
 
 ### Other Tips
 


### PR DESCRIPTION
Apparently Grammarly has a visual studio code extension and it was able to catch a couple of errors. Take a [look](https://marketplace.visualstudio.com/items?itemName=znck.grammarly).
